### PR TITLE
feat: Implement frame-based time system (#8)

### DIFF
--- a/nannou_timeline/Cargo.toml
+++ b/nannou_timeline/Cargo.toml
@@ -15,17 +15,12 @@ egui = "0.24"
 envelope = "0.8"
 itertools = "0.10"
 num = "0.4"
-pitch_calc = { version = "0.12", features = ["serde"] }
-time_calc = { version= "0.13", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 uuid = { version = "1.6", features = ["v4", "serde"] }
 
 [features]
 default = ["serde1"]
-serde1 = [
-    "pitch_calc/serde",
-    "time_calc/serde",
-]
+serde1 = []
 
 [dev-dependencies]
 insta = "1.34"

--- a/nannou_timeline/src/ruler_egui.rs
+++ b/nannou_timeline/src/ruler_egui.rs
@@ -27,7 +27,7 @@ impl Ruler {
         Self::default()
     }
 
-    /// Draw the ruler
+    /// Draw the ruler with frame numbers
     pub fn draw(
         &self,
         ui: &mut Ui,
@@ -36,6 +36,7 @@ impl Ruler {
         end_frame: u32,
         frame_width: f32,
         scroll_offset: f32,
+        frame_labels: &[crate::FrameLabel],
     ) {
         // Background
         ui.painter().rect_filled(
@@ -50,10 +51,11 @@ impl Ruler {
             ui.style().visuals.widgets.noninteractive.bg_stroke,
         );
 
-        // Draw frame numbers and ticks
+        // Calculate visible frame range
         let visible_start = ((scroll_offset / frame_width) as u32).saturating_sub(1);
         let visible_end = visible_start + ((rect.width() / frame_width) as u32) + 2;
 
+        // Draw frame numbers and ticks
         for frame in visible_start..=visible_end.min(end_frame) {
             let x = rect.min.x + (frame as f32 * frame_width) - scroll_offset;
             
@@ -61,26 +63,52 @@ impl Ruler {
                 continue;
             }
 
-            // Major ticks with numbers
-            if frame % self.major_tick_interval == 0 {
+            // Major ticks with numbers (every 10 frames by default, or 5 for wider spacing)
+            let major_interval = if frame_width > 15.0 { 5 } else { 10 };
+            if frame % major_interval == 0 {
+                // Draw frame number
                 ui.painter().text(
-                    pos2(x, rect.center().y),
+                    pos2(x, rect.center().y - 2.0),
                     Align2::CENTER_CENTER,
                     frame.to_string(),
                     FontId::proportional(self.font_size),
                     ui.style().visuals.text_color(),
                 );
 
+                // Draw major tick
                 ui.painter().line_segment(
                     [pos2(x, rect.bottom() - 8.0), pos2(x, rect.bottom())],
                     ui.style().visuals.widgets.noninteractive.bg_stroke,
                 );
             }
-            // Minor ticks
-            else if frame % self.minor_tick_interval == 0 {
+            // Minor ticks (every frame when zoomed in)
+            else if frame_width > 8.0 {
                 ui.painter().line_segment(
                     [pos2(x, rect.bottom() - 4.0), pos2(x, rect.bottom())],
                     ui.style().visuals.widgets.noninteractive.bg_stroke,
+                );
+            }
+        }
+
+        // Draw frame labels
+        for label in frame_labels {
+            if label.frame >= visible_start && label.frame <= visible_end {
+                let x = rect.min.x + (label.frame as f32 * frame_width) - scroll_offset;
+                
+                // Draw label marker
+                let color = label.color.unwrap_or(ui.style().visuals.warn_fg_color);
+                ui.painter().line_segment(
+                    [pos2(x, rect.top()), pos2(x, rect.bottom())],
+                    Stroke::new(2.0, color),
+                );
+                
+                // Draw label text
+                ui.painter().text(
+                    pos2(x + 2.0, rect.top() + 2.0),
+                    Align2::LEFT_TOP,
+                    &label.label,
+                    FontId::proportional(self.font_size * 0.9),
+                    color,
                 );
             }
         }

--- a/nannou_timeline/src/time.rs
+++ b/nannou_timeline/src/time.rs
@@ -1,0 +1,162 @@
+//! Frame-based time system for Flash-style timeline
+
+use serde::{Deserialize, Serialize};
+
+/// Frame-based time representation
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FrameTime {
+    /// Current frame number (0-based)
+    pub frame: u32,
+    /// Frames per second
+    pub fps: f32,
+}
+
+impl FrameTime {
+    /// Create a new FrameTime
+    pub fn new(frame: u32, fps: f32) -> Self {
+        Self { frame, fps }
+    }
+
+    /// Convert to seconds
+    pub fn to_seconds(&self) -> f32 {
+        self.frame as f32 / self.fps
+    }
+
+    /// Create from seconds
+    pub fn from_seconds(seconds: f32, fps: f32) -> Self {
+        Self {
+            frame: (seconds * fps).round() as u32,
+            fps,
+        }
+    }
+
+    /// Format as timecode (HH:MM:SS:FF)
+    pub fn to_timecode(&self) -> String {
+        let total_seconds = self.to_seconds();
+        let hours = (total_seconds / 3600.0).floor() as u32;
+        let minutes = ((total_seconds % 3600.0) / 60.0).floor() as u32;
+        let seconds = (total_seconds % 60.0).floor() as u32;
+        let frames = self.frame % self.fps.round() as u32;
+        
+        format!("{:02}:{:02}:{:02}:{:02}", hours, minutes, seconds, frames)
+    }
+
+    /// Format as seconds
+    pub fn to_seconds_string(&self) -> String {
+        format!("{:.3}s", self.to_seconds())
+    }
+
+    /// Format as frame number
+    pub fn to_frame_string(&self) -> String {
+        format!("Frame {}", self.frame)
+    }
+}
+
+/// Common FPS presets
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum FpsPreset {
+    /// Film (24 fps)
+    Film,
+    /// PAL (25 fps)
+    Pal,
+    /// NTSC (29.97 fps)
+    Ntsc,
+    /// Web (30 fps)
+    Web,
+    /// High frame rate (60 fps)
+    High,
+    /// Custom FPS
+    Custom(f32),
+}
+
+impl FpsPreset {
+    pub fn to_fps(&self) -> f32 {
+        match self {
+            FpsPreset::Film => 24.0,
+            FpsPreset::Pal => 25.0,
+            FpsPreset::Ntsc => 29.97,
+            FpsPreset::Web => 30.0,
+            FpsPreset::High => 60.0,
+            FpsPreset::Custom(fps) => *fps,
+        }
+    }
+
+    pub fn label(&self) -> String {
+        match self {
+            FpsPreset::Film => "24 fps (Film)".to_string(),
+            FpsPreset::Pal => "25 fps (PAL)".to_string(),
+            FpsPreset::Ntsc => "29.97 fps (NTSC)".to_string(),
+            FpsPreset::Web => "30 fps (Web)".to_string(),
+            FpsPreset::High => "60 fps (High)".to_string(),
+            FpsPreset::Custom(fps) => format!("{} fps (Custom)", fps),
+        }
+    }
+
+    pub fn all_presets() -> Vec<FpsPreset> {
+        vec![
+            FpsPreset::Film,
+            FpsPreset::Pal,
+            FpsPreset::Ntsc,
+            FpsPreset::Web,
+            FpsPreset::High,
+        ]
+    }
+}
+
+impl Default for FpsPreset {
+    fn default() -> Self {
+        FpsPreset::Film // 24 fps like Flash default
+    }
+}
+
+/// Frame label for marking important points
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FrameLabel {
+    pub frame: u32,
+    pub label: String,
+    #[serde(skip)]
+    pub color: Option<egui::Color32>,
+}
+
+impl FrameLabel {
+    pub fn new(frame: u32, label: impl Into<String>) -> Self {
+        Self {
+            frame,
+            label: label.into(),
+            color: None,
+        }
+    }
+
+    pub fn with_color(mut self, color: egui::Color32) -> Self {
+        self.color = Some(color);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frame_time_conversion() {
+        let ft = FrameTime::new(24, 24.0);
+        assert_eq!(ft.to_seconds(), 1.0);
+        
+        let ft2 = FrameTime::from_seconds(2.5, 24.0);
+        assert_eq!(ft2.frame, 60);
+    }
+
+    #[test]
+    fn test_timecode_formatting() {
+        let ft = FrameTime::new(3661, 24.0); // 152.54 seconds
+        let timecode = ft.to_timecode();
+        assert!(timecode.starts_with("00:02:32:")); // 2 minutes, 32 seconds
+    }
+
+    #[test]
+    fn test_fps_presets() {
+        assert_eq!(FpsPreset::Film.to_fps(), 24.0);
+        assert_eq!(FpsPreset::Ntsc.to_fps(), 29.97);
+        assert_eq!(FpsPreset::Custom(12.0).to_fps(), 12.0);
+    }
+}

--- a/nannou_timeline/src/ui.rs
+++ b/nannou_timeline/src/ui.rs
@@ -86,4 +86,34 @@ impl crate::RiveEngine for MockRiveEngine {
     fn get_fps(&self) -> f32 {
         self.fps
     }
+    
+    fn insert_frame(&mut self, layer_id: crate::LayerId, frame: u32) {
+        println!("MockRiveEngine: Inserting frame at {} on layer {:?}", frame, layer_id);
+        // In a real implementation, this would modify the timeline data
+    }
+    
+    fn remove_frame(&mut self, layer_id: crate::LayerId, frame: u32) {
+        println!("MockRiveEngine: Removing frame at {} on layer {:?}", frame, layer_id);
+        // In a real implementation, this would modify the timeline data
+    }
+    
+    fn insert_keyframe(&mut self, layer_id: crate::LayerId, frame: u32) {
+        println!("MockRiveEngine: Inserting keyframe at {} on layer {:?}", frame, layer_id);
+        // In a real implementation, this would create a new keyframe
+    }
+    
+    fn clear_keyframe(&mut self, layer_id: crate::LayerId, frame: u32) {
+        println!("MockRiveEngine: Clearing keyframe at {} on layer {:?}", frame, layer_id);
+        // In a real implementation, this would remove the keyframe
+    }
+    
+    fn create_motion_tween(&mut self, layer_id: crate::LayerId, frame: u32) {
+        println!("MockRiveEngine: Creating motion tween at {} on layer {:?}", frame, layer_id);
+        // In a real implementation, this would create a motion tween between keyframes
+    }
+    
+    fn create_shape_tween(&mut self, layer_id: crate::LayerId, frame: u32) {
+        println!("MockRiveEngine: Creating shape tween at {} on layer {:?}", frame, layer_id);
+        // In a real implementation, this would create a shape tween between keyframes
+    }
 }

--- a/nannou_timeline/tests/timeline_tests.rs
+++ b/nannou_timeline/tests/timeline_tests.rs
@@ -125,3 +125,61 @@ mod state_tests {
         assert!(state.selected_frames.is_empty());
     }
 }
+
+#[cfg(test)]
+mod frame_time_tests {
+    use nannou_timeline::{FrameTime, FpsPreset};
+    
+    #[test]
+    fn test_frame_time_operations() {
+        // Test frame to seconds conversion
+        let ft = FrameTime::new(48, 24.0);
+        assert_eq!(ft.to_seconds(), 2.0);
+        
+        // Test seconds to frame conversion
+        let ft2 = FrameTime::from_seconds(3.5, 30.0);
+        assert_eq!(ft2.frame, 105);
+        
+        // Test timecode formatting
+        let ft3 = FrameTime::new(90, 30.0); // 3 seconds at 30fps
+        let timecode = ft3.to_timecode();
+        assert!(timecode.starts_with("00:00:03:"));
+    }
+    
+    #[test]
+    fn test_fps_presets() {
+        assert_eq!(FpsPreset::Film.to_fps(), 24.0);
+        assert_eq!(FpsPreset::Pal.to_fps(), 25.0);
+        assert_eq!(FpsPreset::Ntsc.to_fps(), 29.97);
+        assert_eq!(FpsPreset::Web.to_fps(), 30.0);
+        assert_eq!(FpsPreset::High.to_fps(), 60.0);
+        assert_eq!(FpsPreset::Custom(120.0).to_fps(), 120.0);
+        
+        // Test default
+        assert_eq!(FpsPreset::default(), FpsPreset::Film);
+    }
+    
+    #[test]
+    fn test_fps_labels() {
+        assert_eq!(FpsPreset::Film.label(), "24 fps (Film)");
+        assert_eq!(FpsPreset::Ntsc.label(), "29.97 fps (NTSC)");
+        assert_eq!(FpsPreset::Custom(48.0).label(), "48 fps (Custom)");
+    }
+}
+
+#[test]
+fn test_frame_operations() {
+    use nannou_timeline::ui::MockRiveEngine;
+    let mut engine = MockRiveEngine::new();
+    
+    // Test frame operations (these just print in mock implementation)
+    engine.insert_frame(LayerId::new("layer1"), 10);
+    engine.remove_frame(LayerId::new("layer1"), 10);
+    engine.insert_keyframe(LayerId::new("layer1"), 5);
+    engine.clear_keyframe(LayerId::new("layer1"), 5);
+    engine.create_motion_tween(LayerId::new("layer1"), 15);
+    engine.create_shape_tween(LayerId::new("layer1"), 20);
+    
+    // These operations should complete without panic
+    assert_eq!(engine.get_current_frame(), 0);
+}


### PR DESCRIPTION
## Description
This PR implements the frame-based time system, switching from the musical time structure (bars/beats/PPQN) to Flash's frame-based approach.

## What's Changed
- ✅ Added  struct and  enum for frame-based time representation
- ✅ Removed musical time dependencies (,  crates)
- ✅ Updated ruler to display frame numbers instead of bars
- ✅ Added FPS selector dropdown to playback controls with presets (Film 24fps, PAL 25fps, NTSC 29.97fps, Web 30fps, High 60fps)
- ✅ Implemented frame/keyframe operations via right-click context menu:
  - Insert/Remove Frame (F5/Shift+F5)
  - Insert/Clear Keyframe (F6/Shift+F6)
  - Create Motion/Shape Tweens
  - Insert Frame Labels
- ✅ Added keyboard shortcuts for timeline navigation and frame operations
- ✅ Updated  trait with frame manipulation methods
- ✅ Added comprehensive tests for frame-based time functionality

## Testing
All tests pass:
- Frame to seconds conversion
- FPS preset values and labels
- Timecode formatting
- Frame operations on mock engine

## Screenshots
_Context menu and FPS selector are now implemented in the timeline UI_

Closes #8